### PR TITLE
sanitize zappr configuration

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -22,3 +22,7 @@
 #   (you can also specify `orgs` and `users` and define `groups`)
 #   from:
 #     collaborators: true
+
+approvals:
+  ignore: pr_opener
+  minimum: 1


### PR DESCRIPTION
 - Require only one approval
- Ignore the PR-opener approval